### PR TITLE
Performance improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,165 @@ tests/autogen/generate/build-input-tests/*.test
 tests/autogen/generate/build-output-tests/*.exe
 tests/autogen/generate/build-output-tests/*.f
 tests/autogen/generate/build-output-tests/*.test
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+

--- a/fortranformat/_edit_descriptors.py
+++ b/fortranformat/_edit_descriptors.py
@@ -77,10 +77,13 @@ class QuotedString(object):
 
 # Only in F95
 class B(object):
+    base = 2
+
     def __init__(self):
         self.repeat = None
         self.width = None
         self.min_digits = None
+
     def __repr__(self):
         return '<B repeat=' + str(self.repeat) + \
                 ' width=' + str(self.width) + \
@@ -187,10 +190,13 @@ class H(object):
                 ' char_string=' + str(self.char_string) + '>'
     
 class I(object):
+    base = 10
+
     def __init__(self):
         self.repeat = None
         self.width = None
         self.min_digits = None
+
     def __repr__(self):
         return '<I repeat=' + str(self.repeat) + \
                 ' width=' + str(self.width) + \
@@ -206,10 +212,13 @@ class L(object):
 
 # Only in F95
 class O(object):
+    base = 8
+
     def __init__(self):
         self.repeat = None
         self.width = None
         self.min_digits = None
+
     def __repr__(self):
         return '<O repeat=' + str(self.repeat) + \
                 ' width=' + str(self.width) + \
@@ -272,10 +281,13 @@ class X(object):
 
 # Only in F95
 class Z(object):
+    base = 16
+
     def __init__(self):
         self.repeat = None
         self.width = None
         self.min_digits = None
+
     def __repr__(self):
         return '<Z repeat=' + str(self.repeat) + \
                 ' width=' + str(self.width) + \

--- a/fortranformat/_edit_descriptors.py
+++ b/fortranformat/_edit_descriptors.py
@@ -59,6 +59,8 @@ def get_edit_descriptor_obj(name):
 # All the tokens defined in the F77 specification unless specified
 
 class A(object):
+    is_output = True
+
     def __init__(self):
         self.repeat = None
         self.width = None
@@ -67,6 +69,7 @@ class A(object):
                 ' width=' + str(self.width) + '>'
 
 class QuotedString(object):
+    is_output = False
     def __init__(self, char_string=None):
         self.char_string = char_string
     def get_width(self):
@@ -77,6 +80,7 @@ class QuotedString(object):
 
 # Only in F95
 class B(object):
+    is_output = True
     base = 2
 
     def __init__(self):
@@ -90,24 +94,29 @@ class B(object):
                 ' min_digits=' + str(self.min_digits) + '>'
     
 class BN(object):
+    is_output = False
     def __init__(self):
         pass
     def __repr__(self):
         return '<BN>'
 
 class BZ(object):
+    is_output = False
     def __init__(self):
         pass
     def __repr__(self):
         return '<BZ>'
 
 class Colon(object):
+    is_output = False
     def __init__(self):
         pass
     def __repr__(self):
         return '<Colon>'
     
 class D(object):
+    is_output = True
+
     def __init__(self):
         self.repeat = None
         self.width = None
@@ -118,6 +127,8 @@ class D(object):
                 ' decimal_places=' + str(self.decimal_places) + '>'
 
 class E(object):
+    is_output = True
+
     def __init__(self):
         self.repeat = None
         self.width = None
@@ -131,6 +142,8 @@ class E(object):
     
 # Only in F95
 class EN(object):
+    is_output = True
+
     def __init__(self):
         self.repeat = None
         self.width = None
@@ -144,6 +157,8 @@ class EN(object):
 
 # Only in F95
 class ES(object):
+    is_output = True
+
     def __init__(self):
         self.repeat = None
         self.width = None
@@ -156,6 +171,8 @@ class ES(object):
                 ' exponent=' + str(self.exponent) + '>'
 
 class F(object):
+    is_output = True
+
     def __init__(self):
         self.repeat = None
         self.width = None
@@ -166,9 +183,12 @@ class F(object):
                 ' decimal_places=' + str(self.decimal_places) + '>'
     
 class FormatGroup(object):
+    is_output = False
     pass
 
 class G(object):
+    is_output = True
+
     def __init__(self):
         self.repeat = None
         self.width = None
@@ -182,6 +202,7 @@ class G(object):
 
 # Only in F77
 class H(object):
+    is_output = False
     def __init__(self):
         self.num_chars = None
         self.char_string = None
@@ -190,6 +211,7 @@ class H(object):
                 ' char_string=' + str(self.char_string) + '>'
     
 class I(object):
+    is_output = True
     base = 10
 
     def __init__(self):
@@ -203,6 +225,8 @@ class I(object):
                 ' min_digits=' + str(self.min_digits) + '>'
     
 class L(object):
+    is_output = True
+
     def __init__(self):
         self.repeat = None
         self.width = None
@@ -212,6 +236,7 @@ class L(object):
 
 # Only in F95
 class O(object):
+    is_output = True
     base = 8
 
     def __init__(self):
@@ -225,18 +250,21 @@ class O(object):
                 ' min_digits=' + str(self.min_digits) + '>'
 
 class P(object):
+    is_output = False
     def __init__(self):
         self.scale = None
     def __repr__(self):
         return '<P scale=' + str(self.scale) + '>'
     
 class S(object):
+    is_output = False
     def __init__(self):
         pass
     def __repr__(self):
         return '<S>'
     
 class Slash(object):
+    is_output = False
     def __init__(self):
         self.repeat = None
         pass
@@ -244,36 +272,42 @@ class Slash(object):
         return '<Slash repeat=' + str(self.repeat) + '>'
     
 class SP(object):
+    is_output = False
     def __init__(self):
         pass
     def __repr__(self):
         return '<SP>'
     
 class SS(object):
+    is_output = False
     def __init__(self):
         pass
     def __repr__(self):
         return '<SS>'
     
 class T(object):
+    is_output = False
     def __init__(self):
         self.num_chars = None
     def __repr__(self):
         return '<T num_chars=' + str(self.num_chars) + '>'
     
 class TL(object):
+    is_output = False
     def __init__(self):
         self.num_chars = None
     def __repr__(self):
         return '<TL num_chars=' + str(self.num_chars) + '>'
     
 class TR(object):
+    is_output = False
     def __init__(self):
         self.num_chars = None
     def __repr__(self):
         return '<TR num_chars=' + str(self.num_chars) + '>'
 
 class X(object):
+    is_output = False
     def __init__(self):
         self.num_chars = None
     def __repr__(self):
@@ -281,6 +315,7 @@ class X(object):
 
 # Only in F95
 class Z(object):
+    is_output = True
     base = 16
 
     def __init__(self):
@@ -306,7 +341,6 @@ ED8 = ['P'] # Of form kX only, where k is a signed integer, may omit comma if fo
 ED9 = [':'] # Of form X only, may omit comma either side
 ED10 = ['/'] # Of form X only, may omit following comma and leading comma if no repeat
 REPEATABLE_EDS = ['L', 'A', 'D', 'F', 'B', 'I', 'O', 'Z', 'E', 'EN', 'ES', 'G', '/']
-OUTPUT_EDS = (L, A, D, F, B, I, O, Z, E, EN, ES, G)
 CONTROL_EDS = (BN, BZ, P, SP, SS, S, X, T, TR, TL, Colon, Slash)
 NON_REVERSION_EDS = (P, S, SP, SS, BN, BZ)
 ALL_ED = ED1 + ED2 + ED3 + ED4 + ED5 + ED6 + ED7 + ED8 + ED9 + ED10

--- a/fortranformat/_edit_descriptors.py
+++ b/fortranformat/_edit_descriptors.py
@@ -59,6 +59,7 @@ def get_edit_descriptor_obj(name):
 # All the tokens defined in the F77 specification unless specified
 
 class A(object):
+    name = "A"
     is_non_reversion = False
     is_output = True
 
@@ -70,6 +71,7 @@ class A(object):
                 ' width=' + str(self.width) + '>'
 
 class QuotedString(object):
+    name = "QuotedString"
     is_non_reversion = False
     is_output = False
     def __init__(self, char_string=None):
@@ -82,6 +84,7 @@ class QuotedString(object):
 
 # Only in F95
 class B(object):
+    name = "B"
     is_non_reversion = False
     is_output = True
     base = 2
@@ -97,6 +100,7 @@ class B(object):
                 ' min_digits=' + str(self.min_digits) + '>'
     
 class BN(object):
+    name = "BN"
     is_non_reversion = True
     is_output = False
     def __init__(self):
@@ -105,6 +109,7 @@ class BN(object):
         return '<BN>'
 
 class BZ(object):
+    name = "BZ"
     is_non_reversion = True
     is_output = False
     def __init__(self):
@@ -113,6 +118,7 @@ class BZ(object):
         return '<BZ>'
 
 class Colon(object):
+    name = "Colon"
     is_non_reversion = False
     is_output = False
     def __init__(self):
@@ -121,12 +127,14 @@ class Colon(object):
         return '<Colon>'
     
 class D(object):
+    name = "D"
     is_non_reversion = False
     is_output = True
 
     def __init__(self):
         self.repeat = None
         self.width = None
+        self.exponent = None
         self.decimal_places = None
     def __repr__(self):
         return '<D repeat=' + str(self.repeat) + \
@@ -134,6 +142,7 @@ class D(object):
                 ' decimal_places=' + str(self.decimal_places) + '>'
 
 class E(object):
+    name = "E"
     is_non_reversion = False
     is_output = True
 
@@ -150,6 +159,7 @@ class E(object):
     
 # Only in F95
 class EN(object):
+    name = "EN"
     is_non_reversion = False
     is_output = True
 
@@ -166,6 +176,7 @@ class EN(object):
 
 # Only in F95
 class ES(object):
+    name = "ES"
     is_non_reversion = False
     is_output = True
 
@@ -181,12 +192,14 @@ class ES(object):
                 ' exponent=' + str(self.exponent) + '>'
 
 class F(object):
+    name = "F"
     is_non_reversion = False
     is_output = True
 
     def __init__(self):
         self.repeat = None
         self.width = None
+        self.exponent = None
         self.decimal_places = None
     def __repr__(self):
         return '<F repeat=' + str(self.repeat) + \
@@ -194,11 +207,13 @@ class F(object):
                 ' decimal_places=' + str(self.decimal_places) + '>'
     
 class FormatGroup(object):
+    name = "FormatGroup"
     is_non_reversion = False
     is_output = False
     pass
 
 class G(object):
+    name = "G"
     is_non_reversion = False
     is_output = True
 
@@ -215,6 +230,7 @@ class G(object):
 
 # Only in F77
 class H(object):
+    name = "H"
     is_non_reversion = False
     is_output = False
     def __init__(self):
@@ -225,6 +241,7 @@ class H(object):
                 ' char_string=' + str(self.char_string) + '>'
     
 class I(object):
+    name = "I"
     is_non_reversion = False
     is_output = True
     base = 10
@@ -240,6 +257,7 @@ class I(object):
                 ' min_digits=' + str(self.min_digits) + '>'
     
 class L(object):
+    name = "L"
     is_non_reversion = False
     is_output = True
 
@@ -252,6 +270,7 @@ class L(object):
 
 # Only in F95
 class O(object):
+    name = "O"
     is_non_reversion = False
     is_output = True
     base = 8
@@ -267,6 +286,7 @@ class O(object):
                 ' min_digits=' + str(self.min_digits) + '>'
 
 class P(object):
+    name = "P"
     is_non_reversion = True
     is_output = False
     def __init__(self):
@@ -275,6 +295,7 @@ class P(object):
         return '<P scale=' + str(self.scale) + '>'
     
 class S(object):
+    name = "S"
     is_non_reversion = True
     is_output = False
     def __init__(self):
@@ -283,6 +304,7 @@ class S(object):
         return '<S>'
     
 class Slash(object):
+    name = "Slash"
     is_non_reversion = False
     is_output = False
     def __init__(self):
@@ -292,6 +314,7 @@ class Slash(object):
         return '<Slash repeat=' + str(self.repeat) + '>'
     
 class SP(object):
+    name = "SP"
     is_non_reversion = True
     is_output = False
     def __init__(self):
@@ -300,6 +323,7 @@ class SP(object):
         return '<SP>'
     
 class SS(object):
+    name = "SS"
     is_non_reversion = True
     is_output = False
     def __init__(self):
@@ -308,6 +332,7 @@ class SS(object):
         return '<SS>'
     
 class T(object):
+    name = "T"
     is_non_reversion = False
     is_output = False
     def __init__(self):
@@ -316,6 +341,7 @@ class T(object):
         return '<T num_chars=' + str(self.num_chars) + '>'
     
 class TL(object):
+    name = "TL"
     is_non_reversion = False
     is_output = False
     def __init__(self):
@@ -324,6 +350,7 @@ class TL(object):
         return '<TL num_chars=' + str(self.num_chars) + '>'
     
 class TR(object):
+    name = "TR"
     is_non_reversion = False
     is_output = False
     def __init__(self):
@@ -332,6 +359,7 @@ class TR(object):
         return '<TR num_chars=' + str(self.num_chars) + '>'
 
 class X(object):
+    name = "X"
     is_non_reversion = False
     is_output = False
     def __init__(self):
@@ -341,6 +369,7 @@ class X(object):
 
 # Only in F95
 class Z(object):
+    name = "Z"
     is_non_reversion = False
     is_output = True
     base = 16

--- a/fortranformat/_edit_descriptors.py
+++ b/fortranformat/_edit_descriptors.py
@@ -1,4 +1,4 @@
-from ._exceptions import *
+from ._exceptions import InvalidFormat
 
 def get_edit_descriptor_obj(name):
     '''Returns a new object instance from a string'''

--- a/fortranformat/_edit_descriptors.py
+++ b/fortranformat/_edit_descriptors.py
@@ -59,6 +59,7 @@ def get_edit_descriptor_obj(name):
 # All the tokens defined in the F77 specification unless specified
 
 class A(object):
+    is_non_reversion = False
     is_output = True
 
     def __init__(self):
@@ -69,6 +70,7 @@ class A(object):
                 ' width=' + str(self.width) + '>'
 
 class QuotedString(object):
+    is_non_reversion = False
     is_output = False
     def __init__(self, char_string=None):
         self.char_string = char_string
@@ -80,6 +82,7 @@ class QuotedString(object):
 
 # Only in F95
 class B(object):
+    is_non_reversion = False
     is_output = True
     base = 2
 
@@ -94,6 +97,7 @@ class B(object):
                 ' min_digits=' + str(self.min_digits) + '>'
     
 class BN(object):
+    is_non_reversion = True
     is_output = False
     def __init__(self):
         pass
@@ -101,6 +105,7 @@ class BN(object):
         return '<BN>'
 
 class BZ(object):
+    is_non_reversion = True
     is_output = False
     def __init__(self):
         pass
@@ -108,6 +113,7 @@ class BZ(object):
         return '<BZ>'
 
 class Colon(object):
+    is_non_reversion = False
     is_output = False
     def __init__(self):
         pass
@@ -115,6 +121,7 @@ class Colon(object):
         return '<Colon>'
     
 class D(object):
+    is_non_reversion = False
     is_output = True
 
     def __init__(self):
@@ -127,6 +134,7 @@ class D(object):
                 ' decimal_places=' + str(self.decimal_places) + '>'
 
 class E(object):
+    is_non_reversion = False
     is_output = True
 
     def __init__(self):
@@ -142,6 +150,7 @@ class E(object):
     
 # Only in F95
 class EN(object):
+    is_non_reversion = False
     is_output = True
 
     def __init__(self):
@@ -157,6 +166,7 @@ class EN(object):
 
 # Only in F95
 class ES(object):
+    is_non_reversion = False
     is_output = True
 
     def __init__(self):
@@ -171,6 +181,7 @@ class ES(object):
                 ' exponent=' + str(self.exponent) + '>'
 
 class F(object):
+    is_non_reversion = False
     is_output = True
 
     def __init__(self):
@@ -183,10 +194,12 @@ class F(object):
                 ' decimal_places=' + str(self.decimal_places) + '>'
     
 class FormatGroup(object):
+    is_non_reversion = False
     is_output = False
     pass
 
 class G(object):
+    is_non_reversion = False
     is_output = True
 
     def __init__(self):
@@ -202,6 +215,7 @@ class G(object):
 
 # Only in F77
 class H(object):
+    is_non_reversion = False
     is_output = False
     def __init__(self):
         self.num_chars = None
@@ -211,6 +225,7 @@ class H(object):
                 ' char_string=' + str(self.char_string) + '>'
     
 class I(object):
+    is_non_reversion = False
     is_output = True
     base = 10
 
@@ -225,6 +240,7 @@ class I(object):
                 ' min_digits=' + str(self.min_digits) + '>'
     
 class L(object):
+    is_non_reversion = False
     is_output = True
 
     def __init__(self):
@@ -236,6 +252,7 @@ class L(object):
 
 # Only in F95
 class O(object):
+    is_non_reversion = False
     is_output = True
     base = 8
 
@@ -250,6 +267,7 @@ class O(object):
                 ' min_digits=' + str(self.min_digits) + '>'
 
 class P(object):
+    is_non_reversion = True
     is_output = False
     def __init__(self):
         self.scale = None
@@ -257,6 +275,7 @@ class P(object):
         return '<P scale=' + str(self.scale) + '>'
     
 class S(object):
+    is_non_reversion = True
     is_output = False
     def __init__(self):
         pass
@@ -264,6 +283,7 @@ class S(object):
         return '<S>'
     
 class Slash(object):
+    is_non_reversion = False
     is_output = False
     def __init__(self):
         self.repeat = None
@@ -272,6 +292,7 @@ class Slash(object):
         return '<Slash repeat=' + str(self.repeat) + '>'
     
 class SP(object):
+    is_non_reversion = True
     is_output = False
     def __init__(self):
         pass
@@ -279,6 +300,7 @@ class SP(object):
         return '<SP>'
     
 class SS(object):
+    is_non_reversion = True
     is_output = False
     def __init__(self):
         pass
@@ -286,6 +308,7 @@ class SS(object):
         return '<SS>'
     
 class T(object):
+    is_non_reversion = False
     is_output = False
     def __init__(self):
         self.num_chars = None
@@ -293,6 +316,7 @@ class T(object):
         return '<T num_chars=' + str(self.num_chars) + '>'
     
 class TL(object):
+    is_non_reversion = False
     is_output = False
     def __init__(self):
         self.num_chars = None
@@ -300,6 +324,7 @@ class TL(object):
         return '<TL num_chars=' + str(self.num_chars) + '>'
     
 class TR(object):
+    is_non_reversion = False
     is_output = False
     def __init__(self):
         self.num_chars = None
@@ -307,6 +332,7 @@ class TR(object):
         return '<TR num_chars=' + str(self.num_chars) + '>'
 
 class X(object):
+    is_non_reversion = False
     is_output = False
     def __init__(self):
         self.num_chars = None
@@ -315,6 +341,7 @@ class X(object):
 
 # Only in F95
 class Z(object):
+    is_non_reversion = False
     is_output = True
     base = 16
 
@@ -342,6 +369,5 @@ ED9 = [':'] # Of form X only, may omit comma either side
 ED10 = ['/'] # Of form X only, may omit following comma and leading comma if no repeat
 REPEATABLE_EDS = ['L', 'A', 'D', 'F', 'B', 'I', 'O', 'Z', 'E', 'EN', 'ES', 'G', '/']
 CONTROL_EDS = (BN, BZ, P, SP, SS, S, X, T, TR, TL, Colon, Slash)
-NON_REVERSION_EDS = (P, S, SP, SS, BN, BZ)
 ALL_ED = ED1 + ED2 + ED3 + ED4 + ED5 + ED6 + ED7 + ED8 + ED9 + ED10
 

--- a/fortranformat/_input.py
+++ b/fortranformat/_input.py
@@ -109,7 +109,7 @@ def input(eds, reversion_eds, records, num_vals=None):
             state.update(func(state["position"], ed, record))
         elif isinstance(ed, Slash):
             # End of record
-            record = next_with_default(records, None)
+            record = next(records, None)
             state['position'] = 0
             if record is None:
                 break
@@ -138,7 +138,7 @@ def input(eds, reversion_eds, records, num_vals=None):
             resolved = False
             g_trial_eds = iter(config.G_INPUT_TRIAL_EDS)
             while not resolved:
-                ed_name = next_with_default(g_trial_eds, None)
+                ed_name = next(g_trial_eds, None)
                 if ed_name is None:
                     raise ValueError(
                         'No suitable edit descriptor in config.G_INPUT_TRIAL_EDS')
@@ -221,14 +221,6 @@ def _get_substr(w, record, state):
     substr = record[start:end]
     state['position'] = min(state['position'] + w, len(record))
     return substr, state
-
-
-def next_with_default(it, default=None):
-    try:
-        val = next(it)
-    except StopIteration:
-        val = default
-    return val
 
 
 def read_string(ed, state, record):

--- a/fortranformat/_input.py
+++ b/fortranformat/_input.py
@@ -257,14 +257,6 @@ def read_integer(ed, state, record):
                 'Negative numbers not permitted for binary, octal or hex')
         else:
             return (None, state)
-    if isinstance(ed, Z):
-        base = 16
-    elif isinstance(ed, I):
-        base = 10
-    elif isinstance(ed, O):
-        base = 8
-    elif isinstance(ed, B):
-        base = 2
     # If a negative is followed by blanks, Gfortran and ifort
     # interpret as a zero
     if re.match(r'^ *- +$', substr):
@@ -283,7 +275,7 @@ def read_integer(ed, state, record):
             substr = '0'
     teststr = _interpret_blanks(substr, state)
     try:
-        val = int(teststr, base)
+        val = int(teststr, ed.base)
     except ValueError:
         if state['exception_on_fail']:
             raise ValueError(

--- a/fortranformat/_input.py
+++ b/fortranformat/_input.py
@@ -40,13 +40,13 @@ def input(eds, reversion_eds, records, num_vals=None):
     # values if number of output values is not defined
     num_out_eds = 0
     for ed in eds:
-        if isinstance(ed, OUTPUT_EDS):
+        if ed.is_output:
             num_out_eds += 1
     num_rev_out_eds = 0
     if num_vals is None:
         num_vals = num_out_eds
     for ed in reversion_eds:
-        if isinstance(ed, OUTPUT_EDS):
+        if ed.is_output:
             num_rev_out_eds += 1
 
     # Will loop forever is no output edit descriptors

--- a/fortranformat/_input.py
+++ b/fortranformat/_input.py
@@ -51,16 +51,10 @@ def input(eds, reversion_eds, records, num_vals=None):
     reversion_eds = expand_edit_descriptors(reversion_eds)
     # Assume one-to-one correspondance between edit descriptors and output
     # values if number of output values is not defined
-    num_out_eds = 0
-    for ed in eds:
-        if ed.is_output:
-            num_out_eds += 1
-    num_rev_out_eds = 0
+    num_out_eds = sum((ed.is_output for ed in eds))
+    num_rev_out_eds = sum((ed.is_output for ed in reversion_eds))
     if num_vals is None:
         num_vals = num_out_eds
-    for ed in reversion_eds:
-        if ed.is_output:
-            num_rev_out_eds += 1
 
     # Will loop forever is no output edit descriptors
     if (num_out_eds == 0):

--- a/fortranformat/_input.py
+++ b/fortranformat/_input.py
@@ -1,5 +1,6 @@
 import re
 from ._edit_descriptors import *
+from ._exceptions import InvalidFormat
 from ._misc import expand_edit_descriptors
 from . import config
 

--- a/fortranformat/_input.py
+++ b/fortranformat/_input.py
@@ -74,9 +74,11 @@ def input(eds, reversion_eds, records, num_vals=None):
     # May need to process multiple records, down to a higher function to supply
     # appropriate string for format
     if not hasattr(records, 'next'):
-        records = iter(re.split('\r\n|\r|\n', records))
-    record = next_with_default(records, None)
-    if record is None:
+        records = iter(records.splitlines() or [""])
+
+    try:
+        record = next(records)
+    except StopIteration:
         return []
 
     # if a_widths is not None:

--- a/fortranformat/_input.py
+++ b/fortranformat/_input.py
@@ -294,6 +294,10 @@ def read_logical(ed, state, record):
     return (val, state)
 
 
+DECIMAL_RE = re.compile(r"^ *\. *$")
+MINUS_RE = re.compile(r"^ *- *$")
+EXPONENT_RE = re.compile(r"(.*)E[-+]?$")
+
 def read_float(ed, state, record):
     substr, state = _get_substr(ed.width, record, state)
     teststr = _interpret_blanks(substr, state)
@@ -311,14 +315,14 @@ def read_float(ed, state, record):
         teststr = teststr[0] + \
             teststr[1:].replace('+', 'E+').replace('-', 'E-')
     # ifort allows '.' to be interpreted as 0
-    if re.match(r'^ *\. *$', teststr):
+    if DECIMAL_RE.match(teststr):
         teststr = '0'
     # ifort allows '-' to be interpreted as 0
-    if re.match(r'^ *- *$', teststr):
+    if MINUS_RE.match(teststr):
         teststr = '0'
     # ifort allows numbers to end with 'E', 'E+', 'E-' and 'D'
     # equivalents
-    res = re.match(r'(.*)(E|E\+|E\-)$', teststr)
+    res = EXPONENT_RE.match(teststr)
     if res:
         teststr = res.group(1)
     try:

--- a/fortranformat/_lexer.py
+++ b/fortranformat/_lexer.py
@@ -1,5 +1,5 @@
 from ._edit_descriptors import *
-from ._exceptions import *
+from ._exceptions import InvalidFormat
 
 # Some lexer tokens to look out for
 DIGITS = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '0']

--- a/fortranformat/_output.py
+++ b/fortranformat/_output.py
@@ -62,7 +62,7 @@ def output(eds, reversion_eds, values):
                     if len(tmp_reversion_eds):
                         ed = tmp_reversion_eds.pop()
                         # these edit descriptors are ignored in reversion state
-                        if not isinstance(ed, NON_REVERSION_EDS):
+                        if not ed.is_non_reversion:
                             break
                     else:
                         # Regardless of where cursor is, is moved to the

--- a/fortranformat/_output.py
+++ b/fortranformat/_output.py
@@ -97,66 +97,14 @@ def output(eds, reversion_eds, values):
                     val = 0
                 sub_string = _compose_i_string(
                     ed.width, ed.min_digits, state, val)
-            elif isinstance(ed, B):
+            elif isinstance(ed, (B, O, Z)):
                 if val is None:
                     val = 0
-                w = ed.width
-                m = ed.min_digits
-                sub_string = _compose_boz_string(w, m, state, val, 'B')
-            if isinstance(ed, O):
-                if val is None:
-                    val = 0
-                w = ed.width
-                m = ed.min_digits
-                sub_string = _compose_boz_string(w, m, state, val, 'O')
-            if isinstance(ed, Z):
-                if val is None:
-                    val = 0
-                w = ed.width
-                m = ed.min_digits
-                sub_string = _compose_boz_string(w, m, state, val, 'Z')
-            elif isinstance(ed, F):
+                sub_string = _compose_boz_string(ed.width, ed.min_digits, state, val, ed.name)
+            elif isinstance(ed, (D, E, EN, ES, F, G)):
                 if val is None:
                     val = 0.0
-                w = ed.width
-                e = None
-                d = ed.decimal_places
-                sub_string = _compose_float_string(w, e, d, state, val, 'F')
-            elif isinstance(ed, E):
-                if val is None:
-                    val = 0.0
-                w = ed.width
-                e = ed.exponent
-                d = ed.decimal_places
-                sub_string = _compose_float_string(w, e, d, state, val, 'E')
-            elif isinstance(ed, D):
-                if val is None:
-                    val = 0.0
-                w = ed.width
-                e = None
-                d = ed.decimal_places
-                sub_string = _compose_float_string(w, e, d, state, val, 'D')
-            elif isinstance(ed, G):
-                if val is None:
-                    val = 0.0
-                w = ed.width
-                e = ed.exponent
-                d = ed.decimal_places
-                sub_string = _compose_float_string(w, e, d, state, val, 'G')
-            elif isinstance(ed, EN):
-                if val is None:
-                    val = 0.0
-                w = ed.width
-                e = ed.exponent
-                d = ed.decimal_places
-                sub_string = _compose_float_string(w, e, d, state, val, 'EN')
-            elif isinstance(ed, ES):
-                if val is None:
-                    val = 0.0
-                w = ed.width
-                e = ed.exponent
-                d = ed.decimal_places
-                sub_string = _compose_float_string(w, e, d, state, val, 'ES')
+                sub_string = _compose_float_string(ed.width, ed.exponent, ed.decimal_places, state, val, ed.name)
             elif isinstance(ed, L):
                 if val is None:
                     val = True

--- a/fortranformat/_output.py
+++ b/fortranformat/_output.py
@@ -240,12 +240,7 @@ def _compose_float_string(w, e, d, state, val, ftype):
     zero_flag = (tmp == 0)
     # === DTOA === (macro)
     # write the tmp value to the string buffer
-    # sprintf seems to allow negative number of decimal places, need to correct for this
-    if ndigits <= 0:
-        fmt = '%+-#' + str(PROC_MIN_FIELD_WIDTH) + 'e'
-    else:
-        fmt = '%+-#' + str(PROC_MIN_FIELD_WIDTH) + '.' + str(ndigits - 1) + 'e'
-    buff = fmt % tmp
+    buff = f"{tmp:<+#{PROC_MIN_FIELD_WIDTH}.{max(0, ndigits - 1)}e}"
     # === WRITE_FLOAT === (macro)
     if ftype != 'G':
         return _output_float(w, d, e, state, ftype, buff, sign_bit, zero_flag, ndigits, edigits)

--- a/fortranformat/_output.py
+++ b/fortranformat/_output.py
@@ -92,24 +92,24 @@ def output(eds, reversion_eds, values):
                 # is a edit descriptor that requires a value but no value
                 # we simply ignore at this point - likely this is an incomplete reversion
                 break
-            if isinstance(ed, I):
+            if ed.name == "I":
                 if val is None:
                     val = 0
                 sub_string = _compose_i_string(
                     ed.width, ed.min_digits, state, val)
-            elif isinstance(ed, (B, O, Z)):
+            elif ed.name in ("B", "O", "Z"):
                 if val is None:
                     val = 0
                 sub_string = _compose_boz_string(ed.width, ed.min_digits, state, val, ed.name)
-            elif isinstance(ed, (D, E, EN, ES, F, G)):
+            elif ed.name in ("D", "E", "EN", "ES", "F", "G"):
                 if val is None:
                     val = 0.0
                 sub_string = _compose_float_string(ed.width, ed.exponent, ed.decimal_places, state, val, ed.name)
-            elif isinstance(ed, L):
+            elif ed.name == "L":
                 if val is None:
                     val = True
                 sub_string = _compose_l_string(ed.width, state, val)
-            elif isinstance(ed, A):
+            elif ed.name == "A":
                 if val is None:
                     val = ''
                 sub_string = _compose_a_string(ed.width, state, val)
@@ -117,29 +117,29 @@ def output(eds, reversion_eds, values):
                 record, sub_string, state['position'])
         else:
             # token does not require a value
-            if isinstance(ed, (S, SS)):
+            if ed.name in ("S", "SS"):
                 state['incl_plus'] = False
-            if isinstance(ed, SP):
+            if ed.name == "SP":
                 state['incl_plus'] = True
-            elif isinstance(ed, P):
+            elif ed.name == "P":
                 state['scale'] = ed.scale
-            elif isinstance(ed, BN):
+            elif ed.name == "BN":
                 # This is moot since for output, this does not do anything
                 state['blanks_as_zeros'] = False
-            elif isinstance(ed, BZ):
+            elif ed.name == "BZ":
                 state['blanks_as_zeros'] = True
-            elif isinstance(ed, Colon):
+            elif ed.name == "Colon":
                 state['halt_if_no_vals'] = True
-            elif isinstance(ed, Slash):
+            elif ed.name == "Slash":
                 state['position'], record = _write_string(
                     record, config.RECORD_SEPARATOR, state['position'])
-            elif isinstance(ed, (X, TR)):
+            elif ed.name in ("X", "TR"):
                 state['position'] = state['position'] + ed.num_chars
-            elif isinstance(ed, TL):
+            elif ed.name == "TL":
                 state['position'] = state['position'] - ed.num_chars
-            elif isinstance(ed, T):
+            elif ed.name == "T":
                 state['position'] = ed.num_chars - 1
-            elif isinstance(ed, QuotedString):
+            elif ed.name == "QuotedString":
                 sub_string = ed.char_string
                 state['position'], record = _write_string(
                     record, sub_string, state['position'])

--- a/fortranformat/_output.py
+++ b/fortranformat/_output.py
@@ -497,53 +497,52 @@ def _output_float(w, d, e, state, ft, buff, sign_bit, zero_flag, ndigits, edigit
         nblanks = nblanks - 1
     else:
         leadzero = False
-    out = ''
+
+    out = StringIO()
     # Pad to full field width
     if (nblanks > 0) and not PROC_NO_LEADING_BLANK:  # dtp->u.p.no_leading_blank
-        out = out + ' ' * nblanks
+        out.write(' ' * nblanks)
     # Attach the sign
-    out = out + sign
+    out.write(sign)
     # Add the lead zero if necessary
     if leadzero:
-        out = out + '0'
+        out.write('0')
     # Output portion before the decimal point padded with zeros
     if nbefore > 0:
         if nbefore > ndigits:
-            out = out + digits[:ndigits] + (' ' * (nbefore - ndigits))
+            out.write(digits[:ndigits] + (' ' * (nbefore - ndigits)))
             digits = digits[ndigits:]
             ndigits = 0
         else:
             i = nbefore
-            out = out + digits[:i]
+            out.write(digits[:i])
             digits = digits[i:]
             ndigits = ndigits - i
+
     # Output the decimal point
-    out = out + PROC_DECIMAL_CHAR
+    out.write(PROC_DECIMAL_CHAR)
+
     # Output the leading zeros after the decimal point
     if nzero > 0:
-        out = out + ('0' * nzero)
+        out.write(('0' * nzero))
+
     # Output the digits after the decimal point, padded with zeros
     if nafter > 0:
-        if nafter > ndigits:
-            i = ndigits
-        else:
-            i = nafter
-        zeros = '0' * (nafter - i)
-        out = out + digits[:i] + zeros
-        digits = digits[nafter:]
-        ndigits = ndigits - nafter
+        i = min(nafter, ndigits)
+        out.write(digits[:i])
+        out.write('0' * (nafter - i))
+
     # Output the exponent
     if expchar is not None:
         if expchar != ' ':
-            out = out + expchar
+            out.write(expchar)
             edigits = edigits - 1
-        fmt = '%+0' + str(edigits) + 'd'
-        tmp_buff = fmt % ex
+        tmp_buff = f'{ex:+0{edigits}d}'
         # if not state['blanks_as_zeros']:
         if PROC_NO_LEADING_BLANK:
-            tmp_buf = tmp_buff + (nblanks * ' ')
-        out = out + tmp_buff
-    return out
+            tmp_buff = tmp_buff + (nblanks * ' ')
+        out.write(tmp_buff)
+    return out.getvalue()
 
 
 def _calculate_sign(state, negative_flag):

--- a/fortranformat/_output.py
+++ b/fortranformat/_output.py
@@ -32,7 +32,7 @@ def output(eds, reversion_eds, values):
     # check that if there is a reversion, that values can be output
     reversion_contains_output_ed = False
     for ed in reversion_eds:
-        if isinstance(ed, OUTPUT_EDS):
+        if ed.is_output:
             reversion_contains_output_ed = True
             break
     # Get full list of edit descriptors
@@ -83,7 +83,7 @@ def output(eds, reversion_eds, values):
                 # final value
                 break
         # check if edit descriptor requires a value
-        if isinstance(ed, OUTPUT_EDS):
+        if ed.is_output:
             if get_value.has_next():
                 val = next(get_value)
             else:

--- a/fortranformat/_output.py
+++ b/fortranformat/_output.py
@@ -473,18 +473,7 @@ def _output_float(w, d, e, state, ft, buff, sign_bit, zero_flag, ndigits, edigit
                 edigits = e + 2
     else:
         edigits = 0
-    # Zero values always output as positive, even if the value was egative before rounding
-    i = 0
-    while i < ndigits:
-        if digits[i] != '0':
-            break
-        i = i + 1
-    if i == ndigits:
-        # The output is zero so set sign accordingly
-        if PROC_SIGN_ZERO:
-            sign = _calculate_sign(state, sign_bit)
-        else:
-            sign = _calculate_sign(state, False)
+
     # Pick a field size if none was specified
     if w <= 0:
         w = nbefore + nzero + nafter + 1 + len(sign)

--- a/fortranformat/_output.py
+++ b/fortranformat/_output.py
@@ -546,14 +546,11 @@ def _output_float(w, d, e, state, ft, buff, sign_bit, zero_flag, ndigits, edigit
 
 
 def _calculate_sign(state, negative_flag):
-    s = ''
     if negative_flag:
-        s = '-'
-    elif state['incl_plus']:
-        s = '+'
-    else:
-        s = ''
-    return s
+        return '-'
+    if state['incl_plus']:
+        return '+'
+    return ''
 
 
 def _swapchar(s, ind, newch):

--- a/fortranformat/_output.py
+++ b/fortranformat/_output.py
@@ -325,13 +325,11 @@ def _output_float(w, d, e, state, ft, buff, sign_bit, zero_flag, ndigits, edigit
     if e is None:
         e = -1
     nzero_real = -1
-    sign = _calculate_sign(state, sign_bit)
+
     # Some debug
     if d != 0:
         assert(buff[2] in ['.', ','])
         assert(buff[ndigits + 2] == 'e')
-    # Read in the exponent
-    ex = int(buff[ndigits + 3:]) + 1
     # Handle zero case
     if zero_flag:
         ex = 0
@@ -348,6 +346,11 @@ def _output_float(w, d, e, state, ft, buff, sign_bit, zero_flag, ndigits, edigit
                 return '*'  # This is ifort behaviour
             else:
                 return '.'  # CHANGED: Was '0'
+    else:
+        # Read in the exponent
+        ex = int(buff[ndigits + 3:]) + 1
+        sign = _calculate_sign(state, sign_bit)
+
     # Get rid of the decimal and the initial sign i.e. normalise the digits
     digits = buff[1] + buff[3:]
     # Find out where to place the decimal point

--- a/fortranformat/_output.py
+++ b/fortranformat/_output.py
@@ -492,11 +492,9 @@ def _output_float(w, d, e, state, ft, buff, sign_bit, zero_flag, ndigits, edigit
     if (nblanks < 0) or (edigits == -1):
         return '*' * w
     # See if we have space for a zero before the decimal point
-    if (nbefore == 0) and (nblanks > 0):
-        leadzero = True
+    leadzero = (nbefore == 0) and (nblanks > 0)
+    if leadzero:
         nblanks = nblanks - 1
-    else:
-        leadzero = False
 
     out = StringIO()
     # Pad to full field width

--- a/fortranformat/_output.py
+++ b/fortranformat/_output.py
@@ -1,5 +1,6 @@
 import math
 from ._edit_descriptors import *
+from ._exceptions import InvalidFormat
 from ._misc import expand_edit_descriptors, has_next_iterator
 from . import config
 

--- a/fortranformat/_output.py
+++ b/fortranformat/_output.py
@@ -431,10 +431,10 @@ def _output_float(w, d, e, state, ft, buff, sign_bit, zero_flag, ndigits, edigit
             while i >= 0:
                 digit = int(digits[i])
                 if digit != 9:
-                    digits = _swapchar(digits, i, str(digit + 1))
+                    digits = _swapchar(digits, i, digit + 1)
                     break
                 else:
-                    digits = _swapchar(digits, i, '0')
+                    digits = _swapchar(digits, i, 0)
                 i = i - 1
             # Did the carry overflow?
             if i < 0:
@@ -553,13 +553,11 @@ def _calculate_sign(state, negative_flag):
     return ''
 
 
-def _swapchar(s, ind, newch):
+def _swapchar(s: str, ind: int, newch: int):
     '''
     Helper function to make chars in a string mutableish
     '''
-    if 0 < ind >= len(s):
-        raise IndexError('index out of range')
-    return s[:ind] + newch + s[ind+1:]
+    return f"{s[:ind]}{newch}{s[ind+1:]}"
 
 
 def _compose_a_string(w, state, val):

--- a/fortranformat/_parser.py
+++ b/fortranformat/_parser.py
@@ -1,6 +1,6 @@
 from ._lexer import Token
 from ._edit_descriptors import *
-from ._exceptions import *
+from ._exceptions import InvalidFormat
 from . import config
 
 def parser(tokens, version=None):


### PR DESCRIPTION
This has been a really useful package for me, but the performance is really not great. On the test case below, this PR gave me a x16 speedup, mostly from using `StringIO` as the buffer for writing floats. I've also done some refactoring to avoid `isinstance` calls, which can be expensive.

```python
from fortranformat import FortranRecordWriter, FortranRecordReader

import numpy as np


def test_read_write_array():
    nx = 400
    ny = 100
    array = np.linspace(0, 1, nx * ny).reshape((nx, ny))
    writer = FortranRecordWriter("(5f17.9)")
    text = writer.write(array.flatten("F"))

    reader = FortranRecordReader("(5f17.9)")
    for line in text.splitlines():
        new_array = reader.read(line)



if __name__ == "__main__":
    test_read_write_array()
```

Using `str` as before, this test case scales like O(n^2), with this PR it scales like O(n).

I'll also look at using `StringIO` for the other types.