### PR TITLE
Format markdown docs, refactor examples, fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Cleanup: [pull 33](https://github.com/brendanarnold/py-fortranformat/pull/33) Remove unused setup.cfg - @davidsch
 - Cleanup: [pull 34](https://github.com/brendanarnold/py-fortranformat/pull/34) Remove dependency on nose - @davidsch
 - Cleanup: [pull 36](https://github.com/brendanarnold/py-fortranformat/pull/36) Remove extra files from repo - @mwtoews
+- Cleanup: [pull 37](https://github.com/brendanarnold/py-fortranformat/pull/37) Fix typos, fix Markdown formatting, refactor examples - @mwtoews
 
 ## V 2.0.0
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ buildtests:
 	python tests/autogen/generate/build_unittests.py
 
 runtests:
-  # This takes a few minutes to run
+	# This takes a few minutes to run
 	python -m pytest tests/handwritten
 	python -m pytest tests/autogen/input/ifort/9_1_linux_intel
 	python -m pytest tests/autogen/output/ifort/9_1_linux_intel

--- a/README.md
+++ b/README.md
@@ -4,30 +4,30 @@ Generates text from a Python list of variables or will read a line of text into 
 
 To read Fortran records,
 
-```
-import fortranformat as ff
-header_line = FortranRecordReader('(A15, A15, A15)')
-header_line.read('              x              y              z')
+```pycon
+>>> from fortranformat import FortranRecordReader
+>>> header_line = FortranRecordReader('(A15, A15, A15)')
+>>> header_line.read('              x              y              z')
 ['              x', '              y', '              z']
-line = FortranRecordReader('(3F15.3)')
-line.read('          1.000          0.000          0.500')
-# Returns [1.0, 0.0, 0.5]
-line.read('          1.100          0.100          0.600')
-# Returns [1.1, 0.1, 0.6]
+>>> line = FortranRecordReader('(3F15.3)')
+>>> line.read('          1.000          0.000          0.500')
+[1.0, 0.0, 0.5]
+>>> line.read('          1.100          0.100          0.600')
+[1.1, 0.1, 0.6]
 ```
 
 To write Fortran records,
 
-```
-import fortranformat as ff
-header_line = FortranRecordWriter('(A15, A15, A15)')
-header_line.write(['x', 'y', 'z'])
-# Results in '              x              y              z'
-line = FortranRecordWriter('(3F15.3)')
-line.write([1.0, 0.0, 0.5])
-# Results in '          1.000          0.000          0.500'
-line.write([1.1, 0.1, 0.6])
-# Results in '          1.100          0.100          0.600'
+```pycon
+>>> from fortranformat import FortranRecordWriter
+>>> header_line = FortranRecordWriter('(A15, A15, A15)')
+>>> header_line.write(['x', 'y', 'z'])
+'              x              y              z'
+>>> line = FortranRecordWriter('(3F15.3)')
+>>> line.write([1.0, 0.0, 0.5])
+'          1.000          0.000          0.500'
+>>> line.write([1.1, 0.1, 0.6])
+'          1.100          0.100          0.600'
 ```
 
 For more detailed usage, see [the guide](https://github.com/brendanarnold/py-fortranformat/blob/master/docs/wiki/guide.md).
@@ -55,21 +55,29 @@ Characterisations for a selection of FORTRAN compilers already exists, but if yo
 
 Build the tests using
 
-`make buildtests`
+```
+make buildtests
+```
 
 Make sure that pytest is installed then run using
 
-`make runtests`
+```
+make runtests
+```
 
 Note that some of the F output edit descriptors fail due to limitations in floating point number representation
 
 To run a reduced test suite where time and resources are limited, use the following
 
-`make runminimaltests`
+```
+make runminimaltests
+```
 
 To run a performance test, which currently only covers the reading and writing of floats, use the following
 
-`make runperformancetests`
+```
+make runperformancetests
+```
 
 ### Deploying a new package version
 

--- a/docs/wiki/guide.md
+++ b/docs/wiki/guide.md
@@ -2,20 +2,18 @@
 
 ## Basic usage
 
-```
+```pycon
 >>> from fortranformat import FortranRecordWriter
 >>> format = FortranRecordWriter('(3I10)')
->>> output = format.write([0.0, 1.0, None])
->>> output
+>>> format.write([0, 1, None])
 '         0         1         0'
 ```
 
-```
+```pycon
 >>> from fortranformat import FortranRecordReader
 >>> format = FortranRecordReader('(3I10)')
->>> output = format.read('         0         1')
->>> output
-[0.0, 1.0, None]
+>>> format.read('         0         1')
+[0, 1, None]
 ```
 
 It supports all the edit descriptors found in F77 as well as repeat formats.
@@ -32,15 +30,15 @@ To return FORTRAN default values rather than `None` see `RET_UNWRITTEN_VARS_NONE
 
 #### Example
 
-```
+```pycon
+>>> from fortranformat import config
 >>> format = FortranRecordReader('(3I10)')
->>> output = format.read('         0         1')
->>> output
-[0.0, 1.0, None]
+>>> config.RET_WRITTEN_VARS_ONLY = False  # default
+>>> format.read('         0         1')
+[0, 1, None]
 >>> config.RET_WRITTEN_VARS_ONLY = True
->>> output = format.read('         0         1')
->>> output
-[0.0, 1.0]
+>>> format.read('         0         1')
+[0, 1]
 ```
 
 ### `RET_UNWRITTEN_VARS_NONE`
@@ -53,15 +51,14 @@ To only return written values see `RET_WRITTEN_VARS_ONLY`.
 
 #### Example
 
-```
+```pycon
 >>> format = FortranRecordReader('(3I10)')
->>> output = format.read('         0         1')
->>> output
-[0.0, 1.0, None]
+>>> config.RET_UNWRITTEN_VARS_NONE = True  # default
+>>> format.read('         0         1')
+[0, 1]
 >>> config.RET_UNWRITTEN_VARS_NONE = False
->>> output = format.read('         0         1')
->>> output
-[0.0, 1.0, 0.0]
+>>> format.read('         0         1')
+[0, 1]
 ```
 
 ### `G_INPUT_TRIAL_EDS`
@@ -78,11 +75,9 @@ When wrapping the records, this string is used to delimit the lines.
 
 #### Example
 
-```
+```pycon
 >>> config.RECORD_SEPARATOR = '|'
->>> format = FortranRecordWriter('(2I10)')
->>> output = format.write([0, 0, 0, 0])
->>> output
+>>> FortranRecordWriter('(2I10)').write([0, 0, 0, 0])
 '         0         0|         0         0'
 ```
 
@@ -94,7 +89,7 @@ This mimics the overflow behaviour of FORTRAN as well as the encoding of negativ
 
 #### Example
 
-```
+```pycon
 >>> format = FortranRecordWriter('(Z10)')
 >>> format.write([-10])
 '  FFFFFFF6'
@@ -107,15 +102,12 @@ This mimics the overflow behaviour of FORTRAN as well as the encoding of negativ
 
 Call this to reset the configuration to its defaults
 
-```
+```pycon
 >>> config.RECORD_SEPARATOR = '|'
 >>> format = FortranRecordWriter('(2I10)')
->>> output = format.write([0, 0, 0, 0])
->>> output
+>>> format.write([0, 0, 0, 0])
 '         0         0|         0         0'
 >>> config.reset()
->>> output = format.write([0, 0, 0, 0])
->>> output
+>>> format.write([0, 0, 0, 0])
 '         0         0\n         0         0'
-
 ```

--- a/fortranformat/_input.py
+++ b/fortranformat/_input.py
@@ -46,10 +46,10 @@ def input(eds, reversion_eds, records, num_vals=None):
         if isinstance(ed, tuple(FORBIDDEN_EDS)):
             raise InvalidFormat("%d edit descriptor not permitted on input")
 
-    # Expand repeated edit decriptors
+    # Expand repeated edit descriptors
     eds = expand_edit_descriptors(eds)
     reversion_eds = expand_edit_descriptors(reversion_eds)
-    # Assume one-to-one correspondance between edit descriptors and output
+    # Assume one-to-one correspondence between edit descriptors and output
     # values if number of output values is not defined
     num_out_eds = sum((ed.is_output for ed in eds))
     num_rev_out_eds = sum((ed.is_output for ed in reversion_eds))

--- a/fortranformat/_output.py
+++ b/fortranformat/_output.py
@@ -317,7 +317,7 @@ def _output_float(w, d, e, state, ft, buff, sign_bit, zero_flag, ndigits, edigit
     # nbefore - number of digits before the decimal point
     # nzero - number of zeros after the decimal point
     # nafter - number of digits after the decimal point
-    # nzero_real - number of zeros after the decimal point regardles of the precision
+    # nzero_real - number of zeros after the decimal point regardless of the precision
 
     # Some hacks to change None to -1 (C convention)
     if w is None:

--- a/fortranformat/config.py
+++ b/fortranformat/config.py
@@ -14,11 +14,11 @@ ALLOW_ZERO_WIDTH_EDS = True
 RECORD_SEPARATOR = '\n'
 # Set this to emulate FORTRAN overflow behaviour in Z and I edit descriptors. None means no overflow, 2**31 for 32bit signed int
 PROC_MAXINT = 2**31
-# Processor dependant default for including leading plus or not
+# Processor dependent default for including leading plus or not
 PROC_INCL_PLUS = False
 # Option to allow signed binary, octal and hex on input (not a FORTRAN feature)
 PROC_ALLOW_NEG_BOZ = False
-# Processor dependant padding character
+# Processor dependent padding character
 PROC_PAD_CHAR = ' '
 # Interpret blanks or just a negative as a zero, as in ifort behaviour
 PROC_NEG_AS_ZERO = True

--- a/tests/autogen/generate/gen_input_tests.py
+++ b/tests/autogen/generate/gen_input_tests.py
@@ -576,7 +576,7 @@ def write_fortran_source(formats, inputs, name):
         for ind, fmt in enumerate(formats):
             lbl = ind + 1
             fh.write("%-6dFORMAT (%s)\n" % (lbl, fmt))
-        # Ouptut the closing source
+        # Output the closing source
         fh.write("""
       STOP
       END

--- a/tests/autogen/generate/gen_output_tests.py
+++ b/tests/autogen/generate/gen_output_tests.py
@@ -567,7 +567,7 @@ def write_fortran_source(formats, inputs, name):
     for ind, fmt in enumerate(formats):
         lbl = ind + 1
         fh.write("%-6dFORMAT (A, /, A, /, %s)\n" % (lbl, fmt))
-    # Ouptut the closing source
+    # Output the closing source
     fh.write("""
       STOP
       END

--- a/tests/handwritten/ALLOW_ZERO_WIDTH_EDS-config-tests.py
+++ b/tests/handwritten/ALLOW_ZERO_WIDTH_EDS-config-tests.py
@@ -73,7 +73,7 @@ class AllowZeroWidthEdsConfigTests(unittest.TestCase):
 
     def test_8(self):
         # Positional editdescriptors always raise error when passed a
-        # zero argument, even when ALLOW_ZERO_WIDTH_EDS is explictly
+        # zero argument, even when ALLOW_ZERO_WIDTH_EDS is explicitly
         # specified
         fmt = ('0X')
         config.ALLOW_ZERO_WIDTH_EDS = True
@@ -82,7 +82,7 @@ class AllowZeroWidthEdsConfigTests(unittest.TestCase):
 
     def test_9(self):
         # Positional editdescriptors always raise error when passed a
-        # zero argument, even when ALLOW_ZERO_WIDTH_EDS is explictly
+        # zero argument, even when ALLOW_ZERO_WIDTH_EDS is explicitly
         # not specified
         fmt = ('0X')
         config.ALLOW_ZERO_WIDTH_EDS = False

--- a/tests/handwritten/test_a_ed_input.py
+++ b/tests/handwritten/test_a_ed_input.py
@@ -105,7 +105,7 @@ class AEditDescriptorTests(unittest.TestCase):
         result = [' ']
         self.assertEqual(result, _input(eds, rev_eds, inpt))
 
-    # Test with X (shoud be same as TR)
+    # Test with X (should be same as TR)
 
     def test_x_1(self):
         inpt = '1234567890'

--- a/tests/handwritten/test_multi_input_ed.py
+++ b/tests/handwritten/test_multi_input_ed.py
@@ -48,7 +48,7 @@ class MultiEditDescriptorTests(unittest.TestCase):
 
     def test_4(self):
         # Can change behaviour using configuration. Setting
-        # RET_WRITTEN_VARS_ONLY should remove unwritten varibles from
+        # RET_WRITTEN_VARS_ONLY should remove unwritten variables from
         # returned output (i.e. if run out of record, return only the
         # FORTRAN variables that have been read into)
         inpt = '1'
@@ -61,7 +61,7 @@ class MultiEditDescriptorTests(unittest.TestCase):
 
     def test_5(self):
         # Can change behaviour using configuration. Setting
-        # RET_WRITTEN_VARS_ONLY should remove unwritten varibles from
+        # RET_WRITTEN_VARS_ONLY should remove unwritten variables from
         # returned output (i.e. if run out of record, return only the
         # FORTRAN variables that have been read into)
         inpt = '1'

--- a/tests/misc/raw/a-ed-input-tests.f
+++ b/tests/misc/raw/a-ed-input-tests.f
@@ -14,7 +14,7 @@
 ! abcdefghij
 
 
-! Test where intial read starts beyond left tab-limit, do blanks get
+! Test where initial read starts beyond left tab-limit, do blanks get
 ! read in until position becomes positive?
 ! Gfortran->12345
       C = ''
@@ -23,7 +23,7 @@
       WRITE(*, '(''Left of left-tab-limit:'', A)') C
       CLOSE(10)
 
-! Test where intial read starts beyond end of record
+! Test where initial read starts beyond end of record
 ! Gfortran:-><blank>
       C = ''
       OPEN(10, FILE='a-ed-input-records.txt', STATUS='old')


### PR DESCRIPTION
This PR refactors a few of the examples and other parts of the markdown files.

Also fix a bunch of typos (found using codespell).

The minor fix to the Makefile replaces spaces with a tab.